### PR TITLE
Remove the space from the handler name

### DIFF
--- a/web-config-template
+++ b/web-config-template
@@ -2,7 +2,7 @@
 <configuration>
   <system.webServer>
     <handlers>
-      <add name="Python FastCGI" 
+      <add name="FastCGI" 
       path="*" 
       verb="*" 
       modules="FastCgiModule" 


### PR DESCRIPTION
After a lot of fiddling and internet search on what could be the cause, I found that the space in the name of FastCGI handler is what caused the error. Apparently IIS does not handle spaces well.